### PR TITLE
[ECO-2159] Create `aptos-cli docker` image in `cloud-infra`

### DIFF
--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -1,0 +1,36 @@
+
+---
+    jobs:
+      build-push:
+        runs-on: 'ubuntu-latest'
+        steps:
+        - uses: 'actions/checkout@v4'
+        - id: 'metadata'
+          uses: 'docker/metadata-action@v5'
+          with:
+            images: 'econialabs/aptos-cli'
+            tags: |
+              type=match,pattern=aptos-cli-v(.*),group=1
+        - uses: 'docker/setup-qemu-action@v3'
+        - uses: 'docker/setup-buildx-action@v3'
+        - uses: 'docker/login-action@v3'
+          with:
+            password: '${{ secrets.DOCKERHUB_TOKEN }}'
+            username: '${{ secrets.DOCKERHUB_USERNAME }}'
+        - uses: 'docker/build-push-action@v6'
+          with:
+            cache-from: 'type=gha'
+            cache-to: 'type=gha,mode=max'
+            context: '.'
+            file: 'src/aptos-cli/Dockerfile'
+            labels: '${{ steps.metadata.outputs.labels }}'
+            platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
+            push: 'true'
+            tags: '${{ steps.metadata.outputs.tags }}'
+        timeout-minutes: 360
+    name: 'Build the aptos-cli Docker image and push to Docker Hub'
+    'on':
+      push:
+        tags:
+        - 'aptos-cli-v*'
+...

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -27,6 +27,8 @@
             platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
             push: 'true'
             tags: '${{ steps.metadata.outputs.tags }}'
+            build-args: |
+              GIT_TAG=${{ github.ref_name }}
         timeout-minutes: 360
     name: 'Build the aptos-cli Docker image and push to Docker Hub'
     'on':

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -1,25 +1,42 @@
+# yamllint disable rule:empty-lines rule:key-ordering
 
 ---
+name: 'Build the aptos-cli Docker image and push to Docker Hub'
+
+'on':
+  push:
+    tags:
+    - 'aptos-cli-v*'
+  workflow_dispatch:
+    inputs:
+      cli_version:
+        description: >-
+          Aptos CLI version to build. Accepts both formats: v4.0.0 or 4.0.0
+        required: true
+        type: 'string'
 jobs:
-    build-push:
+  build-push:
     runs-on: 'ubuntu-latest'
     steps:
     - uses: 'actions/checkout@v4'
     - id: 'metadata'
-        uses: 'docker/metadata-action@v5'
-        with:
+      uses: 'docker/metadata-action@v5'
+      with:
         images: 'econialabs/aptos-cli'
-        tags: |
-            type=match,pattern=aptos-cli-v(.*),group=1,enable=${{ github.event_name == 'push' }}
-            type=raw,value=${{ github.event.inputs.cli_version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+        tags: >
+          type=match,pattern=aptos-cli-v(.*),group=1,
+          enable=${{ github.event_name == 'push' }}
+
+          type=raw,value=${{ github.event.inputs.cli_version }},
+          enable=${{ github.event_name == 'workflow_dispatch' }}
     - uses: 'docker/setup-qemu-action@v3'
     - uses: 'docker/setup-buildx-action@v3'
     - uses: 'docker/login-action@v3'
-        with:
+      with:
         password: '${{ secrets.DOCKERHUB_TOKEN }}'
         username: '${{ secrets.DOCKERHUB_USERNAME }}'
     - uses: 'docker/build-push-action@v6'
-        with:
+      with:
         cache-from: 'type=gha'
         cache-to: 'type=gha,mode=max'
         context: '.'
@@ -29,17 +46,6 @@ jobs:
         platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
         tags: '${{ steps.metadata.outputs.tags }}'
         build-args: |
-            CLI_VERSION=${{ steps.metadata.outputs.tags }}
+          CLI_VERSION=${{ steps.metadata.outputs.tags }}
     timeout-minutes: 360
-name: 'Build the aptos-cli Docker image and push to Docker Hub'
-'on':
-    push:
-      tags:
-      - 'aptos-cli-v*'
-    workflow_dispatch:
-        inputs:
-        cli_version:
-            description: 'Aptos CLI version to build. Accepts both formats: v4.0.0 or 4.0.0'
-            required: true
-            type: string
 ...

--- a/.github/workflows/push-aptos-cli.yaml
+++ b/.github/workflows/push-aptos-cli.yaml
@@ -1,38 +1,45 @@
 
 ---
-    jobs:
-      build-push:
-        runs-on: 'ubuntu-latest'
-        steps:
-        - uses: 'actions/checkout@v4'
-        - id: 'metadata'
-          uses: 'docker/metadata-action@v5'
-          with:
-            images: 'econialabs/aptos-cli'
-            tags: |
-              type=match,pattern=aptos-cli-v(.*),group=1
-        - uses: 'docker/setup-qemu-action@v3'
-        - uses: 'docker/setup-buildx-action@v3'
-        - uses: 'docker/login-action@v3'
-          with:
-            password: '${{ secrets.DOCKERHUB_TOKEN }}'
-            username: '${{ secrets.DOCKERHUB_USERNAME }}'
-        - uses: 'docker/build-push-action@v6'
-          with:
-            cache-from: 'type=gha'
-            cache-to: 'type=gha,mode=max'
-            context: '.'
-            file: 'src/aptos-cli/Dockerfile'
-            labels: '${{ steps.metadata.outputs.labels }}'
-            platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
-            push: 'true'
-            tags: '${{ steps.metadata.outputs.tags }}'
-            build-args: |
-              GIT_TAG=${{ github.ref_name }}
-        timeout-minutes: 360
-    name: 'Build the aptos-cli Docker image and push to Docker Hub'
-    'on':
-      push:
-        tags:
-        - 'aptos-cli-v*'
+jobs:
+    build-push:
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'actions/checkout@v4'
+    - id: 'metadata'
+        uses: 'docker/metadata-action@v5'
+        with:
+        images: 'econialabs/aptos-cli'
+        tags: |
+            type=match,pattern=aptos-cli-v(.*),group=1,enable=${{ github.event_name == 'push' }}
+            type=raw,value=${{ github.event.inputs.cli_version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+    - uses: 'docker/setup-qemu-action@v3'
+    - uses: 'docker/setup-buildx-action@v3'
+    - uses: 'docker/login-action@v3'
+        with:
+        password: '${{ secrets.DOCKERHUB_TOKEN }}'
+        username: '${{ secrets.DOCKERHUB_USERNAME }}'
+    - uses: 'docker/build-push-action@v6'
+        with:
+        cache-from: 'type=gha'
+        cache-to: 'type=gha,mode=max'
+        context: '.'
+        file: 'src/aptos-cli/Dockerfile'
+        push: true
+        labels: '${{ steps.metadata.outputs.labels }}'
+        platforms: '${{ vars.DOCKER_IMAGE_PLATFORMS }}'
+        tags: '${{ steps.metadata.outputs.tags }}'
+        build-args: |
+            CLI_VERSION=${{ steps.metadata.outputs.tags }}
+    timeout-minutes: 360
+name: 'Build the aptos-cli Docker image and push to Docker Hub'
+'on':
+    push:
+      tags:
+      - 'aptos-cli-v*'
+    workflow_dispatch:
+        inputs:
+        cli_version:
+            description: 'Aptos CLI version to build. Accepts both formats: v4.0.0 or 4.0.0'
+            required: true
+            type: string
 ...

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -1,0 +1,46 @@
+# cspell:word RUSTFLAGS
+
+ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
+ARG GIT_TAG
+
+ARG CLI_BINARY=/aptos-core/target/cli/aptos
+
+FROM rust:1-bookworm AS aptos-cli
+
+ARG GIT_REPO
+ARG GIT_TAG
+ARG CLI_BINARY
+
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
+RUN git clone --depth 1 --branch $GIT_TAG $GIT_REPO \
+    && apt-get update && apt-get install --no-install-recommends -y \
+        libudev-dev=252.26-1~deb12u2 \
+        build-essential=12.9 \
+        libclang-dev=1:14.0-55.7~deb12u1 \
+        libpq-dev=15.8-0+deb12u1 \
+        libssl-dev=3.0.13-1~deb12u1 \
+        libdw-dev=0.188-2.1 \
+        pkg-config=1.8.1-1 \
+        lld=1:14.0-55.7~deb12u1 \
+        curl=7.88.1-10+deb12u6 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Resolve outdated lockfile from upstream tag, build the binary,
+# and strip it to reduce its size.
+RUN cargo update --manifest-path /aptos-core/Cargo.toml && \
+    RUSTFLAGS="--cfg tokio_unstable" cargo build \
+    --bin aptos \
+    --manifest-path /aptos-core/Cargo.toml \
+    --profile cli && \
+    strip -s $CLI_BINARY
+
+FROM ubuntu:noble
+WORKDIR /app
+
+# Copy the executable to `/usr/local/bin` and add it to the PATH.
+ENV PATH=/usr/local/bin:$PATH
+ARG CLI_BINARY
+COPY --from=aptos-cli $CLI_BINARY /usr/local/bin
+
+STOPSIGNAL SIGKILL

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -1,7 +1,10 @@
 # cspell:word RUSTFLAGS
 
 ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
-ARG GIT_TAG
+ARG CLI_VERSION
+
+# Remove the leading `v` if the version begins with it.
+ARG GIT_TAG="aptos-cli-v$(echo $CLI_VERSION | sed 's/^v//')"
 
 ARG CLI_BINARY=/aptos-core/target/cli/aptos
 

--- a/src/aptos-cli/Dockerfile
+++ b/src/aptos-cli/Dockerfile
@@ -1,4 +1,8 @@
 # cspell:word RUSTFLAGS
+# cspell:word libudev
+# cspell:word libclang
+# cspell:word libpq
+# cspell:word libdw
 
 ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
 ARG CLI_VERSION

--- a/src/aptos-cli/README.md
+++ b/src/aptos-cli/README.md
@@ -5,7 +5,8 @@ it isn't readily available for use as a Docker image specifically for the
 `linux/arm64/v8` aka `aarch64` processor architecture, more commonly known as
 the M1/M2 chips that Macbooks use.
 
-This Docker builds a simple image of the `aptos` CLI, with the CLI version corresponding directly Docker image tag:
+This Docker builds a simple image of the `aptos` CLI, with the CLI version
+corresponding directly Docker image tag:
 
 ```Dockerfile
 # Uses the aptos CLI, version 4.0.0
@@ -18,14 +19,42 @@ RUN aptos --version
 ## Building the image and pushing it to the `econialabs` Docker hub
 
 To build a Docker image with a specific version of the Aptos CLI, simply push
-the corresponding version tag to GitHub to trigger the GitHub workflow that builds the image in CI:
+the corresponding version tag to GitHub to trigger the GitHub workflow that
+builds the image in CI:
 
 ```shell
 git tag aptos-cli-v4.0.0
 ```
 
-This will trigger the GitHub `push-aptos-cli.yaml` workflow to build the `aptos` CLI Docker image and subsequently push it to the `econialabs` Dockerhub repository as `econialabs/aptos-cli:4.0.0`.
+This will trigger the GitHub `push-aptos-cli.yaml` workflow to build the `aptos`
+CLI Docker image and subsequently push it to the `econialabs` Dockerhub
+repository as `econialabs/aptos-cli:4.0.0`.
 
 ## Multi-architecture support
 
 Currently the GitHub action triggers builds for `arm64` and `amd64`.
+
+## Building it yourself locally
+
+If you'd like to build the image yourself, you can simply pass the CLI version
+as a `build-arg`.
+
+A simple `bash` script for this process might be something like:
+
+```bash
+#!/bin/bash
+
+# From the root of this repository.
+git_root=$(git rev-parse --show-toplevel)
+
+username=YOUR_DOCKERHUB_USERNAME
+version=v4.0.0
+
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --build-arg GIT_TAG=aptos-cli-$version \
+  -t $username/aptos-cli:$version \
+  -f $git_root/src/aptos-cli/Dockerfile \
+  --push \
+  .
+```

--- a/src/aptos-cli/README.md
+++ b/src/aptos-cli/README.md
@@ -14,3 +14,18 @@ FROM econialabs/aptos-cli:4.0.0
 RUN aptos --version
 # > aptos 4.0.0
 ```
+
+## Building the image and pushing it to the `econialabs` Docker hub
+
+To build a Docker image with a specific version of the Aptos CLI, simply push
+the corresponding version tag to GitHub to trigger the GitHub workflow that builds the image in CI:
+
+```shell
+git tag aptos-cli-v4.0.0
+```
+
+This will trigger the GitHub `push-aptos-cli.yaml` workflow to build the `aptos` CLI Docker image and subsequently push it to the `econialabs` Dockerhub repository as `econialabs/aptos-cli:4.0.0`.
+
+## Multi-architecture support
+
+Currently the GitHub action triggers builds for `arm64` and `amd64`.

--- a/src/aptos-cli/README.md
+++ b/src/aptos-cli/README.md
@@ -1,0 +1,16 @@
+# Objective
+
+While the Aptos CLI tool is available for different platforms and architectures,
+it isn't readily available for use as a Docker image specifically for the
+`linux/arm64/v8` aka `aarch64` processor architecture, more commonly known as
+the M1/M2 chips that Macbooks use.
+
+This Docker builds a simple image of the `aptos` CLI, with the CLI version corresponding directly Docker image tag:
+
+```Dockerfile
+# Uses the aptos CLI, version 4.0.0
+FROM econialabs/aptos-cli:4.0.0
+
+RUN aptos --version
+# > aptos 4.0.0
+```

--- a/src/aptos-cli/README.md
+++ b/src/aptos-cli/README.md
@@ -1,12 +1,23 @@
+<!--
+cspell:word aarch
+cspell:word toplevel
+cspell:word Macbooks
+-->
+
 # Objective
 
-While the Aptos CLI tool is available for different platforms and architectures,
-it isn't readily available for use as a Docker image specifically for the
-`linux/arm64/v8` aka `aarch64` processor architecture, more commonly known as
-the M1/M2 chips that Macbooks use.
+The Aptos CLI is available for various platforms and architectures as a
+standalone executable; however, there isn't a ready-to-use Docker image for the
+`aarch64` processor architecture (labeled as `linux/arm64/v8` in Docker).
 
-This Docker builds a simple image of the `aptos` CLI, with the CLI version
-corresponding directly Docker image tag:
+This architecture is particularly significant, as it's used in the arm-based
+Apple silicon found in newer Macbooks.
+
+The image built from this Dockerfile serves to address this gap and provide a
+solution for users working with these systems.
+
+It builds an image of the `aptos` CLI for `linux/arm64` and `linux/amd64`, with
+the CLI version corresponding directly Docker image tag:
 
 ```Dockerfile
 # Uses the aptos CLI, version 4.0.0

--- a/src/aptos-cli/README.md
+++ b/src/aptos-cli/README.md
@@ -30,6 +30,21 @@ This will trigger the GitHub `push-aptos-cli.yaml` workflow to build the `aptos`
 CLI Docker image and subsequently push it to the `econialabs` Dockerhub
 repository as `econialabs/aptos-cli:4.0.0`.
 
+## Triggering the workflow manually
+
+The action is also set to trigger manually on `workflow_dispatch`.
+
+You will be prompted to input the version, which will work with both of the
+following formats:
+
+`cli_version: v4.0.0`
+
+or
+
+`cli_version: 4.0.0`
+
+Since the Dockerfile strips the `v` when parsing the `ARG CLI_VERSION` value.
+
 ## Multi-architecture support
 
 Currently the GitHub action triggers builds for `arm64` and `amd64`.


### PR DESCRIPTION
# Description

- [x] Match the CLI version with the `GIT_TAG` in the docker build time arg
- [x] Create a GitHub action that parses the version from the git tag and passes it to the build time arg
- [x] This way our tag in `cloud-infra` corresponds to the CLI version used in the resultant image that's built
- [x] Keep `libssl-dev`, can keep `git` and `curl` separate
- [x] Force push `aptos-node-v4.0.0` to main to have a main tag in `econialabs/aptos-cli`
- [x] Add the ability to trigger the action on `workflow_dispatch`
  - [x] Require an input on dispatch
  - [x] Conditionally select the tag in the `metadata-action` action based on whether or not it's a `workflow_dispatch` event or a `push` event

# Testing

Triggering it manually, then with a tag later, maybe.

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you update the changelog?
- [x] Did you check all checkboxes from the linked Linear task?
